### PR TITLE
Fix taskRegexp to consider Task ARNs having cluster name

### DIFF
--- a/task/run.go
+++ b/task/run.go
@@ -50,10 +50,10 @@ func (t *Task) Run() error {
 }
 
 // buildLogStream returns a CloudWatchLog Stream name from ECS task.
-// Task ARN format is `arn:aws:ecs:<region>:<aws_account_id>:task/c5cba4eb-5dad-405e-96db-71ef8eefe6a8`.
+// Task ARN format is `arn:aws:ecs:<region>:<aws_account_id>:task(/<cluster_name>)/c5cba4eb-5dad-405e-96db-71ef8eefe6a8`.
 // And Log Stream format is `stream_prefix/container_name/task_id`.
 func (t *Task) buildLogStream(task *ecs.Task) string {
 	arn := *task.TaskArn
-	taskRegexp := regexp.MustCompile(`task\/([a-z\d\-]+)`)
+	taskRegexp := regexp.MustCompile(`\/([a-z\d\-]+)$`)
 	return taskRegexp.FindStringSubmatch(arn)[1]
 }

--- a/task/run_test.go
+++ b/task/run_test.go
@@ -8,12 +8,33 @@ import (
 )
 
 func TestBuildLogStream(t *testing.T) {
-	task := &Task{}
-	ECSTask := &ecs.Task{
-		TaskArn: aws.String("arn:aws:ecs:ap-northeast-1:1234567890:task/c5cba4eb-5dad-405e-96db-71ef8eefe6a8"),
+	tests := []struct {
+		name     string
+		arn      string
+		expected string
+	}{
+		{
+			name:     "TaskArnWithoutCluster",
+			arn:      "arn:aws:ecs:ap-northeast-1:1234567890:task/c5cba4eb-5dad-405e-96db-71ef8eefe6a8",
+			expected: "c5cba4eb-5dad-405e-96db-71ef8eefe6a8",
+		},
+		{
+			name:     "TaskArnWithCluster",
+			arn:      "arn:aws:ecs:ap-northeast-1:1234567890:task/my-cluster/c5cba4eb-5dad-405e-96db-71ef8eefe6a8",
+			expected: "c5cba4eb-5dad-405e-96db-71ef8eefe6a8",
+		},
 	}
-	taskID := task.buildLogStream(ECSTask)
-	if taskID != "c5cba4eb-5dad-405e-96db-71ef8eefe6a8" {
-		t.Error("Task ID is invalid")
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			task := &Task{}
+			ECSTask := &ecs.Task{
+				TaskArn: aws.String(tt.arn),
+			}
+			taskID := task.buildLogStream(ECSTask)
+			if taskID != tt.expected {
+				t.Error("Task ID is invalid")
+			}
+		})
 	}
 }


### PR DESCRIPTION
Hi, thanks for the useful tool!

I have encountered a problem that logs of running task is not shown on stdout.
After some investigation, the reason seems that my ECS task ARN has cluster name between `task` and `/<task_id>` like 

`arn:aws:ecs:ap-northeast-1:1234567890:task/my-cluster/c5cba4eb-5dad-405e-96db-71ef8eefe6a8`

so that the `buildLogStream` method returns `my-cluster`, which is not task ID, then ecs-task cannot get log stream related to the task.

So I changed the regexp to get task ID like this PR to make ecs-task support task both ARN type (with and withiout cluster name).