### PR TITLE
add platformVersion option

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -18,6 +18,7 @@ type runTask struct {
 	fargate         bool
 	timeout         int
 	timestampFormat string
+	platformVersion string
 }
 
 func runTaskCmd() *cobra.Command {
@@ -38,6 +39,7 @@ func runTaskCmd() *cobra.Command {
 	flags.BoolVarP(&r.fargate, "fargate", "f", false, "Whether run task with FARGATE")
 	flags.IntVarP(&r.timeout, "timeout", "t", 0, "Timeout seconds")
 	flags.StringVarP(&r.timestampFormat, "timestamp-format", "", "[2006-01-02 15:04:05.999999999 -0700 MST]", "Format of timestamp for outputs. You should follow the style of Time.Format (see https://golang.org/pkg/time/#pkg-constants)")
+	flags.StringVarP(&r.platformVersion, "platform-version", "p", "", "The platform version that your tasks in the service are running on. A platform version is specified only for tasks using the Fargate launch type. If one isn't specified, the LATEST platform version is used by default.")
 
 	return cmd
 }
@@ -47,7 +49,7 @@ func (r *runTask) run(cmd *cobra.Command, args []string) {
 	if !verbose {
 		log.SetLevel(log.WarnLevel)
 	}
-	t, err := task.NewTask(r.cluster, r.container, r.taskDefinition, r.command, r.fargate, r.subnets, r.securityGroups, (time.Duration(r.timeout) * time.Second), r.timestampFormat, profile, region)
+	t, err := task.NewTask(r.cluster, r.container, r.taskDefinition, r.command, r.fargate, r.subnets, r.securityGroups, r.platformVersion, (time.Duration(r.timeout) * time.Second), r.timestampFormat, profile, region)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/pkg/task/task.go
+++ b/pkg/task/task.go
@@ -89,6 +89,8 @@ type Task struct {
 	Subnets []*string
 	// If you want to attach the security groups to ENI of the task, please set this.
 	SecurityGroups []*string
+	// If you set Fargate as launch type, you have to set your Platform Version.
+	PlatformVersion string
 	// If you don't enable this flag, the task access the internet throguth NAT gateway.
 	// Please read more information: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-networking.html
 	AssignPublicIP  string
@@ -100,7 +102,7 @@ type Task struct {
 // NewTask returns a new Task struct, and initialize aws ecs API client.
 // If you want to run the task as Fargate, please provide fargate flag to true, and your subnet IDs for awsvpc.
 // If you don't want to run the task as Fargate, please provide empty string for subnetIDs.
-func NewTask(cluster, container, taskDefinitionName, command string, fargate bool, subnetIDs, securityGroupIDs string, timeout time.Duration, timestampFormat, profile, region string) (*Task, error) {
+func NewTask(cluster, container, taskDefinitionName, command string, fargate bool, subnetIDs, securityGroupIDs, platformVersion string, timeout time.Duration, timestampFormat, profile, region string) (*Task, error) {
 	if cluster == "" {
 		return nil, errors.New("Cluster name is required")
 	}
@@ -158,6 +160,7 @@ func NewTask(cluster, container, taskDefinitionName, command string, fargate boo
 		profile:            profile,
 		region:             region,
 		timestampFormat:    timestampFormat,
+		PlatformVersion:    platformVersion,
 	}, nil
 }
 
@@ -183,12 +186,23 @@ func (t *Task) RunTask(ctx context.Context, taskDefinition *ecs.TaskDefinition) 
 		network := &ecs.NetworkConfiguration{
 			AwsvpcConfiguration: vpcConfiguration,
 		}
-		params = &ecs.RunTaskInput{
-			Cluster:              aws.String(t.Cluster),
-			TaskDefinition:       taskDefinition.TaskDefinitionArn,
-			Overrides:            override,
-			NetworkConfiguration: network,
-			LaunchType:           aws.String(t.LaunchType),
+		if len(t.PlatformVersion) > 0 {
+			params = &ecs.RunTaskInput{
+				Cluster:              aws.String(t.Cluster),
+				TaskDefinition:       taskDefinition.TaskDefinitionArn,
+				Overrides:            override,
+				NetworkConfiguration: network,
+				LaunchType:           aws.String(t.LaunchType),
+				PlatformVersion:      aws.String(t.PlatformVersion),
+			}
+		} else {
+			params = &ecs.RunTaskInput{
+				Cluster:              aws.String(t.Cluster),
+				TaskDefinition:       taskDefinition.TaskDefinitionArn,
+				Overrides:            override,
+				NetworkConfiguration: network,
+				LaunchType:           aws.String(t.LaunchType),
+			}
 		}
 	} else {
 		params = &ecs.RunTaskInput{


### PR DESCRIPTION
I received the following email from AWS

Starting March 8, 2021, AWS Fargate is changing the platform version (PV) LATEST flag to resolve to PV 1.4.0 instead of PV 1.3.0 [1]. PV 1.4.0 was launched in April 2020 and introduces a number of new features and changes [2].
[1] https://docs.aws.amazon.com/AmazonECS/latest/developerguide/platform_versions.html
[2] https://aws.amazon.com/jp/blogs/news/aws-fargate-launches-platform-version-1-4/

Therefore, I changed the option of ecs-task so that I can specify the platform version.