### PR TITLE
Stop task on signal

### DIFF
--- a/pkg/task/config.go
+++ b/pkg/task/config.go
@@ -4,32 +4,20 @@ import (
 	"os"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/credentials"
-	"github.com/aws/aws-sdk-go/aws/defaults"
+	"github.com/aws/aws-sdk-go/aws/client"
+	"github.com/aws/aws-sdk-go/aws/session"
 )
 
-// newConfig returns a new aws config
-func newConfig(profile string, region string) *aws.Config {
-	defaultConfig := defaults.Get().Config
-	cred := newCredentials(getenv(profile, "AWS_DEFAULT_PROFILE"), getenv(region, "AWS_DEFAULT_REGION"))
-	return defaultConfig.WithCredentials(cred).WithRegion(getenv(region, "AWS_DEFAULT_REGION"))
-}
-
-func newCredentials(profile string, region string) *credentials.Credentials {
-	// temporary config to resolve RemoteCredProvider
-	tmpConfig := defaults.Get().Config.WithRegion(region)
-	tmpHandlers := defaults.Handlers()
-
-	return credentials.NewChainCredentials(
-		[]credentials.Provider{
-			// Read profile before environment variables
-			&credentials.SharedCredentialsProvider{
-				Profile: profile,
-			},
-			&credentials.EnvProvider{},
-			// for IAM Task Role (ECS) and IAM Role
-			defaults.RemoteCredProvider(*tmpConfig, tmpHandlers),
-		})
+// newConfig returns a new aws ConfigProvider
+func newConfig(profile string, region string) (client.ConfigProvider, error) {
+	sess, err := session.NewSessionWithOptions(session.Options{
+		Config: aws.Config{
+			Region: &region,
+		},
+		Profile: profile,
+		SharedConfigState: session.SharedConfigEnable,
+	})
+	return sess, err
 }
 
 func getenv(value, key string) string {

--- a/pkg/task/run.go
+++ b/pkg/task/run.go
@@ -3,7 +3,6 @@ package task
 import (
 	"context"
 	"regexp"
-	"sync"
 	"time"
 
 	"github.com/aws/aws-sdk-go/service/ecs"
@@ -30,13 +29,10 @@ func (t *Task) Run() error {
 	if err != nil {
 		return err
 	}
-	var wg sync.WaitGroup
 
 	taskID := t.buildLogStream(task)
 	w := NewWatcher(group, streamPrefix+"/"+t.Container+"/"+taskID, t.awsLogs, t.timestampFormat)
-	wg.Add(1)
 	go func() {
-		defer wg.Done()
 		err := w.Polling(ctx)
 		log.Error(err)
 	}()

--- a/pkg/task/run.go
+++ b/pkg/task/run.go
@@ -22,7 +22,7 @@ func (t *Task) Run() error {
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	if t.Timeout != 0 {
-		ctx, cancel = context.WithTimeout(context.Background(), t.Timeout)
+		ctx, cancel = context.WithTimeout(ctx, t.Timeout)
 	}
 	defer cancel()
 

--- a/pkg/task/run.go
+++ b/pkg/task/run.go
@@ -33,7 +33,7 @@ func (t *Task) Run() error {
 	var wg sync.WaitGroup
 
 	taskID := t.buildLogStream(task)
-	w := NewWatcher(group, streamPrefix+"/"+t.Container+"/"+taskID, t.profile, t.region, t.timestampFormat)
+	w := NewWatcher(group, streamPrefix+"/"+t.Container+"/"+taskID, t.awsLogs, t.timestampFormat)
 	wg.Add(1)
 	go func() {
 		defer wg.Done()

--- a/pkg/task/run.go
+++ b/pkg/task/run.go
@@ -26,24 +26,24 @@ func (t *Task) Run() error {
 	}
 	defer cancel()
 
-	tasks, err := t.RunTask(ctx, taskDef)
+	task, err := t.RunTask(ctx, taskDef)
 	if err != nil {
 		return err
 	}
 	var wg sync.WaitGroup
 
-	for _, task := range tasks {
-		taskID := t.buildLogStream(task)
-		w := NewWatcher(group, streamPrefix+"/"+t.Container+"/"+taskID, t.profile, t.region, t.timestampFormat)
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			err := w.Polling(ctx)
-			log.Error(err)
-		}()
-	}
+	taskID := t.buildLogStream(task)
+	w := NewWatcher(group, streamPrefix+"/"+t.Container+"/"+taskID, t.profile, t.region, t.timestampFormat)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		err := w.Polling(ctx)
+		log.Error(err)
+	}()
 
-	err = t.WaitTask(ctx, tasks)
+	err = t.WaitTask(ctx, task)
+	
+
 	time.Sleep(10 * time.Second)
 	cancel()
 	return err

--- a/pkg/task/task.go
+++ b/pkg/task/task.go
@@ -265,7 +265,7 @@ retry:
 			Cluster: aws.String(t.Cluster),
 			Tasks:   []*string {taskArn},
 		}
-		resp, err := t.awsECS.DescribeTasks(params)
+		resp, err := t.awsECS.DescribeTasksWithContext(ctx, params)
 		if err != nil {
 			return err
 		}

--- a/pkg/task/task.go
+++ b/pkg/task/task.go
@@ -113,7 +113,7 @@ func NewTask(cluster, container, taskDefinitionName, command string, fargate boo
 		return nil, errors.New("Task definition is required")
 	}
 	if command == "" {
-		return nil, errors.New("Comamnd is reqired")
+		return nil, errors.New("Command is required")
 	}
 	awsECS := ecs.New(session.New(), newConfig(profile, region))
 	taskDefinition := NewTaskDefinition(profile, region)

--- a/pkg/task/task.go
+++ b/pkg/task/task.go
@@ -115,7 +115,11 @@ func NewTask(cluster, container, taskDefinitionName, command string, fargate boo
 	if command == "" {
 		return nil, errors.New("Command is required")
 	}
-	awsECS := ecs.New(session.New(), newConfig(profile, region))
+	ses, err := session.NewSession()
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to create AWS Session")
+	}
+	awsECS := ecs.New(ses, newConfig(profile, region))
 	taskDefinition := NewTaskDefinition(profile, region)
 	p := shellwords.NewParser()
 	commands, err := p.Parse(command)

--- a/pkg/task/task_definition.go
+++ b/pkg/task/task_definition.go
@@ -2,7 +2,6 @@ package task
 
 import (
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ecs"
 	"github.com/aws/aws-sdk-go/service/ecs/ecsiface"
 	"github.com/pkg/errors"
@@ -14,8 +13,7 @@ type TaskDefinition struct {
 }
 
 // NewTaskDefinition returns a new TaskDefinition struct, and initialize aws ecs API client.
-func NewTaskDefinition(profile, region string) *TaskDefinition {
-	awsECS := ecs.New(session.New(), newConfig(profile, region))
+func NewTaskDefinition(awsECS ecsiface.ECSAPI) *TaskDefinition {
 	return &TaskDefinition{
 		awsECS,
 	}

--- a/pkg/task/task_test.go
+++ b/pkg/task/task_test.go
@@ -110,12 +110,10 @@ func TestWaitTask(t *testing.T) {
 		Timeout:   10 * time.Second,
 	}
 	ctx := context.Background()
-	tasks := []*ecs.Task{
-		&ecs.Task{
+	ecstask := ecs.Task{
 			TaskArn: aws.String("test-arn"),
-		},
-	}
-	err := task.WaitTask(ctx, tasks)
+		}
+	err := task.WaitTask(ctx, &ecstask)
 	if err != nil {
 		t.Error(err)
 	}

--- a/pkg/task/task_test.go
+++ b/pkg/task/task_test.go
@@ -26,11 +26,11 @@ func (m mockedRunTask) RunTaskWithContext(ctx aws.Context, in *ecs.RunTaskInput,
 	return &m.Run, nil
 }
 
-func (m mockedRunTask) DescribeTasks(in *ecs.DescribeTasksInput) (*ecs.DescribeTasksOutput, error) {
+func (m mockedRunTask) DescribeTasksWithContext(ctx aws.Context, in *ecs.DescribeTasksInput, options ...request.Option) (*ecs.DescribeTasksOutput, error) {
 	return &m.Describe, nil
 }
 
-func (m mockedWaitTask) DescribeTasks(in *ecs.DescribeTasksInput) (*ecs.DescribeTasksOutput, error) {
+func (m mockedWaitTask) DescribeTasksWithContext(ctx aws.Context, in *ecs.DescribeTasksInput, options ...request.Option) (*ecs.DescribeTasksOutput, error) {
 	return &m.Describe, nil
 }
 

--- a/pkg/task/watcher.go
+++ b/pkg/task/watcher.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
-	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
 	"github.com/aws/aws-sdk-go/service/cloudwatchlogs/cloudwatchlogsiface"
 	"github.com/pkg/errors"
@@ -23,8 +22,7 @@ type Watcher struct {
 }
 
 // NewWatcher returns a Watcher struct.
-func NewWatcher(group, stream, profile, region, timestampFormat string) *Watcher {
-	awsLogs := cloudwatchlogs.New(session.New(), newConfig(profile, region))
+func NewWatcher(group, stream string, awsLogs cloudwatchlogsiface.CloudWatchLogsAPI, timestampFormat string) *Watcher {
 	return &Watcher{
 		Group:           group,
 		Stream:          stream,

--- a/pkg/task/watcher.go
+++ b/pkg/task/watcher.go
@@ -109,8 +109,8 @@ func (w *Watcher) Polling(ctx context.Context) error {
 func (w *Watcher) printEvents(events []*cloudwatchlogs.OutputLogEvent) {
 	for _, event := range events {
 		// AWS returns milliseconds of unix time.
-		// So we have to transfer to second.
-		timestamp := time.Unix((*event.Timestamp / 1000), 0)
+		// So we have to transfer to second, nanoseconds.
+		timestamp := time.Unix(*event.Timestamp / 1000, *event.Timestamp % 1000 * 1000000)
 		message := *event.Message
 		sTimestamp := timestamp.Format(w.timestampFormat)
 		if sTimestamp != "" {

--- a/pkg/task/watcher_test.go
+++ b/pkg/task/watcher_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
 	"github.com/aws/aws-sdk-go/service/cloudwatchlogs/cloudwatchlogsiface"
 )
@@ -14,7 +15,7 @@ type mockedWatcher struct {
 	StreamsResp cloudwatchlogs.DescribeLogStreamsOutput
 }
 
-func (m mockedWatcher) DescribeLogStreams(in *cloudwatchlogs.DescribeLogStreamsInput) (*cloudwatchlogs.DescribeLogStreamsOutput, error) {
+func (m mockedWatcher) DescribeLogStreamsWithContext(ctx context.Context, in *cloudwatchlogs.DescribeLogStreamsInput, options ...request.Option) (*cloudwatchlogs.DescribeLogStreamsOutput, error) {
 	return &m.StreamsResp, nil
 }
 


### PR DESCRIPTION
feat: Include fractional seconds in the log messages

feat: Use Session to create Credentials (to support more credential resolutions such as `sso_account_id` in `~/.aws/config`)

feat: Stop task on timeout or signal. Previously, when the --timeout was hit or ecs-task was interrupted, it exited immediately without cleaning anything up. This commit makes ecs-task call StopTask, followed by waiting up to 1 minute for the task to complete, followed by waiting 10 seconds for any additional logs.

